### PR TITLE
Fix non working commands

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,6 @@
 [
 	{
-		"keys": ["ctrl+alt+f"], "command": "semistandard_format",
+		"keys": ["ctrl+alt+f"], "command": "semi_standard_format",
 		"context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
 	}
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,6 @@
 [
     {
-        "keys": ["ctrl+alt+f"], "command": "semistandard_format",
+        "keys": ["ctrl+alt+f"], "command": "semi_standard_format",
         "context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,6 @@
 [
     {
-        "keys": ["ctrl+alt+f"], "command": "semistandard_format",
+        "keys": ["ctrl+alt+f"], "command": "semi_standard_format",
         "context": [{"key": "selector", "operator": "equal", "operand": "source.js,source.json"}]
     }
 ]

--- a/Main.sublime-menu
+++ b/Main.sublime-menu
@@ -70,7 +70,7 @@
               },
               { "caption": "-" },
               {
-                  "command": "toggle_semistandard_format",
+                  "command": "toggle_semi_standard_format",
                   "caption": "Format On Save",
                   "checkbox": true
               }

--- a/SemiStandardFormat.sublime-commands
+++ b/SemiStandardFormat.sublime-commands
@@ -1,11 +1,11 @@
 [
     {
       "caption": "SemiStandard Format: Format current file",
-      "command": "semistandard_format"
+      "command": "semi_standard_format"
     },
     {
       "caption": "SemiStandard Format: Toggle format on save",
-      "command": "toggle_semistandard_format"
+      "command": "toggle_semi_standard_format"
     },
     {
         "caption": "Preferences: SemiStandard Format Settings – Default",

--- a/semistandard-format.py
+++ b/semistandard-format.py
@@ -129,7 +129,7 @@ class SemiStandardFormatEventListener(sublime_plugin.EventListener):
     def on_pre_save(self, view):
         if settings.get("format_on_save") and is_javascript(view):
             os.chdir(os.path.dirname(view.file_name()))
-            view.run_command("semistandard_format")
+            view.run_command("semi_standard_format")
 
     def on_activated_async(self, view):
         search_path = generate_search_path(view)


### PR DESCRIPTION
This fixes the commands that don't work -- even after restarting sublime -- after installing the plugin.

Why is that?
Because the python classes are named `SemiStandardFormatCommand` and `ToggleSemiStandardFormatCommand` (i.e. CamelCased `SemiStandard`), sublime automatically adds an underscore into the command name, making it `semi_standard_format` and `toggle_semi_standard_format`.

One could also rename the classes to be `SemistandardFormatCommand` and `ToggleSemistandardFormatCommand` resp. but I chose the other way.